### PR TITLE
docs: seed Wiki (enable + note in CONTRIBUTING)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Thanks for your interest in improving this project! We welcome issues and pull r
 
 ## Repository metadata
 - Add helpful topics to increase discoverability: `pdf`, `compression`, `optimizer`, `ghostscript`, `qpdf`, `cli`, `macos`, `linux`, `psnr`, `ssim`, `ocr`, `jbig2`.
-- See `docs/` for detailed notes; a GitHub Wiki can be enabled to mirror `docs/`.
+- See `docs/` for detailed notes; a GitHub Wiki is enabled and can mirror `docs/`.
 
 ## License
 By contributing, you agree your contributions are licensed under the MIT License.


### PR DESCRIPTION
This PR adds a note that the GitHub Wiki is enabled and can mirror docs/.\n\nFollow-ups:\n- Seed Wiki Home/Usage/Quality-Gates/Roadmap pages.\n- Move extended docs to Wiki pages.\n\nRefs: #3 (Wiki seeding tracking issue), Discussion #2 (Welcome & Roadmap).