### PR TITLE
docs: add Wiki links & badge in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Thanks for your interest in improving this project! We welcome issues and pull r
 
 ## Repository metadata
 - Add helpful topics to increase discoverability: `pdf`, `compression`, `optimizer`, `ghostscript`, `qpdf`, `cli`, `macos`, `linux`, `psnr`, `ssim`, `ocr`, `jbig2`.
-- See `docs/` for detailed notes; a GitHub Wiki can be enabled to mirror `docs/`.
+- See `docs/` for detailed notes; a GitHub Wiki is enabled and can mirror `docs/`.
 
 ## License
 By contributing, you agree your contributions are licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Discussions](https://img.shields.io/badge/Chat-Discussions-blue)](https://github.com/laguileracl/pdf-ultra-compressor/discussions)
+[![Wiki](https://img.shields.io/badge/Wiki-enabled-blueviolet)](https://github.com/laguileracl/pdf-ultra-compressor/wiki)
 
-Command-line, quality-first PDF optimizer for text- and image-heavy PDFs. Drop files into `input/`, get optimized results in `output/`. Focus: maximum size reduction without perceptible quality loss, with strict “never worse” guards. See `docs/` for more details.
+Command-line, quality-first PDF optimizer for text- and image-heavy PDFs. Drop files into `input/`, get optimized results in `output/`. Focus: maximum size reduction without perceptible quality loss, with strict “never worse” guards. See `docs/` for more details. For longer docs, visit the [Wiki](https://github.com/laguileracl/pdf-ultra-compressor/wiki).
 
 Keywords: pdf compression, pdf optimizer, ghostscript, qpdf, ocr, jbig2, jpeg2000, lossless, high quality, macos, linux, ci, command line
 


### PR DESCRIPTION
Add a Wiki badge and link to make long-form docs discoverable.\n\nFollow-ups:\n- Seed and iterate Wiki pages.\n- Move advanced docs from docs/ to Wiki.\n\nRefs: #3 (Wiki seeding), Discussion #2.