### PR TITLE
docs: add Wiki page content (Home, Usage, Quality Gates, Roadmap)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Thanks for your interest in improving this project! We welcome issues and pull r
 
 ## Repository metadata
 - Add helpful topics to increase discoverability: `pdf`, `compression`, `optimizer`, `ghostscript`, `qpdf`, `cli`, `macos`, `linux`, `psnr`, `ssim`, `ocr`, `jbig2`.
-- See `docs/` for detailed notes; a GitHub Wiki can be enabled to mirror `docs/`.
+- See `docs/` for detailed notes; a GitHub Wiki is enabled and can mirror `docs/`.
 
 ## License
 By contributing, you agree your contributions are licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Discussions](https://img.shields.io/badge/Chat-Discussions-blue)](https://github.com/laguileracl/pdf-ultra-compressor/discussions)
+[![Wiki](https://img.shields.io/badge/Wiki-enabled-blueviolet)](https://github.com/laguileracl/pdf-ultra-compressor/wiki)
 
-Command-line, quality-first PDF optimizer for text- and image-heavy PDFs. Drop files into `input/`, get optimized results in `output/`. Focus: maximum size reduction without perceptible quality loss, with strict “never worse” guards. See `docs/` for more details.
+Command-line, quality-first PDF optimizer for text- and image-heavy PDFs. Drop files into `input/`, get optimized results in `output/`. Focus: maximum size reduction without perceptible quality loss, with strict “never worse” guards. See `docs/` for more details. For longer docs, visit the [Wiki](https://github.com/laguileracl/pdf-ultra-compressor/wiki).
 
 Keywords: pdf compression, pdf optimizer, ghostscript, qpdf, ocr, jbig2, jpeg2000, lossless, high quality, macos, linux, ci, command line
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,7 @@
+# Home
+
+Welcome to the PDF Ultra Compressor Wiki.
+
+- [[Usage]]
+- [[Quality Gates]]
+- [[Roadmap]]

--- a/docs/wiki/Quality-Gates.md
+++ b/docs/wiki/Quality-Gates.md
@@ -1,0 +1,4 @@
+# Quality Gates
+
+- PSNR gate (default 35 dB) prevents visible degradation.
+- Never-worse: falls back to original when not improved.

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -1,0 +1,5 @@
+# Roadmap
+
+- OCRmyPDF + JBIG2 (MRC) for scanned PDFs
+- SSIM/LPIPS quality gates (PSNR is available)
+- Benchmark suite & dataset

--- a/docs/wiki/Usage.md
+++ b/docs/wiki/Usage.md
@@ -1,0 +1,6 @@
+# Usage
+
+- Put PDFs in input/
+- Run: `python3 compressor.py`
+- Outputs to output/
+- Originals are moved to input/processed/


### PR DESCRIPTION
Adds initial Wiki page content under docs/wiki/ for later sync into the GitHub Wiki.\n\nOnce the wiki repo is provisioned, we can copy these pages over.\n\nRefs: #3 (Wiki seeding), Discussion #2 (Welcome & Roadmap).